### PR TITLE
Optimise storage memory usage

### DIFF
--- a/handlers/aws/sqs_trigger.py
+++ b/handlers/aws/sqs_trigger.py
@@ -84,11 +84,13 @@ def _handle_sqs_event(config: Config, event: dict[str, Any]) -> Iterator[tuple[d
                 range_start=last_ending_offset,
             )
             for log_event, ending_offset, newline_length in events:
+                assert isinstance(log_event, bytes)
+
                 # let's be sure that on the first yield `ending_offset`
                 # doesn't overlap `last_ending_offset`: in case we
                 # skip in order to not ingest twice the same event
                 if ending_offset < last_ending_offset:
-                    shared_logger.debug(
+                    shared_logger.warn(
                         "skipping event",
                         extra={
                             "ending_offset": ending_offset,

--- a/infra/aws/cloudformation/template.yaml
+++ b/infra/aws/cloudformation/template.yaml
@@ -67,7 +67,7 @@ Metadata:
     Name: elastic-serverless-agent
     Description: elastic-serverless-agent
     Author: elastic
-    SemanticVersion: 0.8.0
+    SemanticVersion: 0.9.0
 
 Outputs:
   ElasticServerlessAgentFunction:

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -3,5 +3,5 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 
 from .factory import StorageFactory
-from .s3 import CHUNK_SIZE, S3Storage
-from .storage import CommonStorage
+from .s3 import S3Storage
+from .storage import CHUNK_SIZE, CommonStorage, StorageReader

--- a/storage/decorator.py
+++ b/storage/decorator.py
@@ -2,25 +2,29 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-import zlib
-from typing import Any, Iterator
+import gzip
+from io import BytesIO
+from typing import Any, Iterator, Union
 
 from share import shared_logger
 
-from .storage import CommonStorageType, GetByLinesCallable
+from .storage import CHUNK_SIZE, CommonStorageType, GetByLinesCallable, StorageReader
 
 
 def by_lines(func: GetByLinesCallable[CommonStorageType]) -> GetByLinesCallable[CommonStorageType]:
     def wrapper(
         storage: CommonStorageType, range_start: int, body: Any, content_type: str, content_length: int
-    ) -> Iterator[tuple[bytes, int, int]]:
+    ) -> Iterator[tuple[Union[StorageReader, bytes], int, int]]:
         offset: int = range_start
         unfinished_line: bytes = b""
 
         newline: bytes = b""
         newline_length: int = 0
+
         iterator = func(storage, range_start, body, content_type, content_length)
-        for data, range_start, _newline_length in iterator:
+        for data, line_ending_offset, _newline_length in iterator:
+            assert isinstance(data, bytes)
+
             unfinished_line += data
             lines = unfinished_line.decode("UTF-8").splitlines()
 
@@ -59,22 +63,24 @@ def by_lines(func: GetByLinesCallable[CommonStorageType]) -> GetByLinesCallable[
 def inflate(func: GetByLinesCallable[CommonStorageType]) -> GetByLinesCallable[CommonStorageType]:
     def wrapper(
         storage: CommonStorageType, range_start: int, body: Any, content_type: str, content_length: int
-    ) -> Iterator[tuple[bytes, int, int]]:
+    ) -> Iterator[tuple[Union[StorageReader, bytes], int, int]]:
         iterator = func(storage, range_start, body, content_type, content_length)
-        for data, range_start, newline_length in iterator:
+        for data, line_ending_offset, newline_length in iterator:
             if content_type == "application/x-gzip":
-                d = zlib.decompressobj(wbits=zlib.MAX_WBITS + 16)
-                decoded: bytes = d.decompress(data)
-                content_length = len(decoded)
-                if range_start < content_length:
-                    chunk = decoded[range_start:]
-                    shared_logger.debug("inflate gzip", extra={"offset": range_start})
-                    yield chunk, range_start, 0
-                else:
-                    shared_logger.info(f"requested file content from {range_start}, file size {len(decoded)}: skip it")
+                gzip_stream = gzip.GzipFile(fileobj=data)  # type:ignore
+                gzip_stream.seek(range_start)
+                while True:
+                    inflated_chunk: bytes = gzip_stream.read(CHUNK_SIZE)
+                    if len(inflated_chunk) == 0:
+                        break
 
+                    buffer: BytesIO = BytesIO()
+                    buffer.write(inflated_chunk)
+
+                    shared_logger.debug("inflate inflate", extra={"offset": line_ending_offset})
+                    yield buffer.getvalue(), line_ending_offset, 0
             else:
-                shared_logger.debug("inflate plain", extra={"offset": range_start})
-                yield data, range_start, 0
+                shared_logger.debug("inflate plain", extra={"offset": line_ending_offset})
+                yield data, line_ending_offset, 0
 
     return wrapper

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -3,7 +3,20 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Iterator, TypeVar
+from typing import Any, Callable, Iterator, TypeVar, Union
+
+CHUNK_SIZE: int = 1024
+
+
+class StorageReader:
+    def __init__(self, raw: Any):
+        self._raw = raw
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._raw.__call_(*args, **kwargs)
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._raw, item)
 
 
 class CommonStorage(metaclass=ABCMeta):
@@ -12,7 +25,7 @@ class CommonStorage(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def get_by_lines(self, range_start: int) -> Iterator[tuple[bytes, int, int]]:
+    def get_by_lines(self, range_start: int) -> Iterator[tuple[Union[StorageReader, bytes], int, int]]:
         raise NotImplementedError
 
     @abstractmethod
@@ -21,4 +34,6 @@ class CommonStorage(metaclass=ABCMeta):
 
 
 CommonStorageType = TypeVar("CommonStorageType", bound=CommonStorage)
-GetByLinesCallable = Callable[[CommonStorageType, int, Any, str, int], Iterator[tuple[bytes, int, int]]]
+GetByLinesCallable = Callable[
+    [CommonStorageType, int, Any, str, int], Iterator[tuple[Union[StorageReader, bytes], int, int]]
+]

--- a/tests/storage/test_s3.py
+++ b/tests/storage/test_s3.py
@@ -90,7 +90,7 @@ class TestS3Storage(TestCase):
     @mock.patch("storage.S3Storage._s3_client.head_object", new=MockContent.s3_client_head_object)
     @mock.patch("storage.S3Storage._s3_client.get_object", new=MockContent.s3_client_get_object)
     def test_get_by_lines(self) -> None:
-        for newline in ["\r\n"]:
+        for newline in ["\n", "\r\n"]:
             with self.subTest(f"testing with newline length {len(newline)}", newline=newline):
                 MockContent.init_content(newline)
 

--- a/tests/storage/test_s3.py
+++ b/tests/storage/test_s3.py
@@ -6,22 +6,22 @@ import gzip
 import io
 import random
 import string
-from typing import Any, Optional
+from typing import Any, Optional, Union
 from unittest import TestCase
 
 import mock
 from botocore.response import StreamingBody
 
-import storage
-from storage import S3Storage
+from storage import S3Storage, StorageReader
 
 
 class MockContent:
-    f_size_plain: int = 0
     f_size_gzip: int = 0
-    f_content: bytes = b""
-    f_stream_plain: Optional[io.BytesIO] = None
+    f_size_plain: int = 0
+    f_content_gzip: bytes = b""
+    f_content_plain: bytes = b""
     f_stream_gzip: Optional[io.BytesIO] = None
+    f_stream_plain: Optional[io.BytesIO] = None
 
     @staticmethod
     def rewind() -> None:
@@ -32,20 +32,20 @@ class MockContent:
 
     @staticmethod
     def init_content(newline: str) -> None:
-        MockContent.f_content = newline.join(
+        MockContent.f_content_plain = newline.join(
             [
                 "".join(random.choices(string.ascii_letters + string.digits, k=random.randint(0, 20)))
-                for _ in range(0, storage.CHUNK_SIZE)
+                for _ in range(0, 1024 ** 2)
             ]
         ).encode("UTF-8")
 
-        f_content_gzip: bytes = gzip.compress(MockContent.f_content)
-        MockContent.f_stream_gzip = io.BytesIO(f_content_gzip)
-        MockContent.f_stream_plain = io.BytesIO(MockContent.f_content)
+        MockContent.f_content_gzip = gzip.compress(MockContent.f_content_plain)
+        MockContent.f_stream_gzip = io.BytesIO(MockContent.f_content_gzip)
+        MockContent.f_stream_plain = io.BytesIO(MockContent.f_content_plain)
         MockContent.rewind()
 
-        MockContent.f_size_gzip = len(f_content_gzip)
-        MockContent.f_size_plain = len(MockContent.f_content)
+        MockContent.f_size_gzip = len(MockContent.f_content_gzip)
+        MockContent.f_size_plain = len(MockContent.f_content_plain)
 
     @staticmethod
     def s3_client_head_object(Bucket: str, Key: str) -> dict[str, Any]:
@@ -63,11 +63,12 @@ class MockContent:
         assert MockContent.f_stream_plain is not None
         MockContent.f_stream_plain.seek(range_int)
         content_body = MockContent.f_stream_plain
-        content_length = len(MockContent.f_content[range_int:])
+        content_length = len(MockContent.f_content_plain[range_int:])
         if Key.endswith(".gz"):
             assert MockContent.f_stream_gzip is not None
+            MockContent.f_stream_gzip.seek(range_int)
             content_body = MockContent.f_stream_gzip
-            content_length = MockContent.f_size_gzip
+            content_length = len(MockContent.f_content_gzip[range_int:])
 
         return {"Body": StreamingBody(content_body, content_length), "ContentLength": content_length}
 
@@ -80,43 +81,53 @@ class TestS3Storage(TestCase):
 
         s3_storage = S3Storage(bucket_name="dummy_bucket", object_key="dummy.key")
         content: bytes = s3_storage.get_as_string().encode("UTF-8")
-        assert content == MockContent.f_content
-        assert len(content) == len(MockContent.f_content)
+        assert content == MockContent.f_content_plain
+        assert len(content) == len(MockContent.f_content_plain)
 
     @mock.patch("storage.S3Storage._s3_client.head_object", new=MockContent.s3_client_head_object)
     @mock.patch("storage.S3Storage._s3_client.get_object", new=MockContent.s3_client_get_object)
     def test_get_by_lines(self) -> None:
-        for newline in ["\r\n", "\n"]:
+        for newline in ["\r\n"]:
             with self.subTest(f"testing with newline length {len(newline)}", newline=newline):
                 MockContent.init_content(newline)
 
                 bucket_name: str = "dummy_bucket"
 
                 s3_storage = S3Storage(bucket_name=bucket_name, object_key="dummy.key.gz")
-                gzip_full: list[tuple[bytes, int, int]] = list(s3_storage.get_by_lines(range_start=0))
+                gzip_full: list[tuple[Union[StorageReader, bytes], int, int]] = list(
+                    s3_storage.get_by_lines(range_start=0)
+                )
 
                 s3_storage = S3Storage(bucket_name=bucket_name, object_key="dummy.key")
-                plain_full: list[tuple[bytes, int, int]] = list(s3_storage.get_by_lines(range_start=0))
+                plain_full: list[tuple[Union[StorageReader, bytes], int, int]] = list(
+                    s3_storage.get_by_lines(range_start=0)
+                )
+
+                gzip_full_01 = gzip_full[: int(len(gzip_full) / 2)]
+                plain_full_01 = plain_full[: int(len(plain_full) / 2)]
 
                 diff = set(gzip_full) ^ set(plain_full)
                 assert not diff
                 assert plain_full == gzip_full
+                assert gzip_full[-1][1] == MockContent.f_size_plain
                 assert plain_full[-1][1] == MockContent.f_size_plain
-                assert newline.join([x[0].decode("UTF-8") for x in plain_full]).encode("UTF-8") == MockContent.f_content
-
-                MockContent.rewind()
-
-                gzip_full_01 = gzip_full[: int(len(gzip_full) / 2)]
-                plain_full_01 = plain_full[: int(len(plain_full) / 2)]
+                assert (
+                    newline.join([x[0].decode("UTF-8") for x in plain_full]).encode("UTF-8")
+                    == MockContent.f_content_plain
+                )
 
                 MockContent.rewind()
 
                 range_start = plain_full_01[-1][1]
                 s3_storage = S3Storage(bucket_name=bucket_name, object_key="dummy.key.gz")
-                gzip_full_02: list[tuple[bytes, int, int]] = list(s3_storage.get_by_lines(range_start=range_start))
+                gzip_full_02: list[tuple[Union[StorageReader, bytes], int, int]] = list(
+                    s3_storage.get_by_lines(range_start=range_start)
+                )
 
                 s3_storage = S3Storage(bucket_name=bucket_name, object_key="dummy.key")
-                plain_full_02: list[tuple[bytes, int, int]] = list(s3_storage.get_by_lines(range_start=range_start))
+                plain_full_02: list[tuple[Union[StorageReader, bytes], int, int]] = list(
+                    s3_storage.get_by_lines(range_start=range_start)
+                )
 
                 diff = set(gzip_full_01) ^ set(plain_full_01)
                 assert not diff
@@ -125,13 +136,51 @@ class TestS3Storage(TestCase):
                 diff = set(gzip_full_02) ^ set(plain_full_02)
                 assert not diff
                 assert plain_full_02 == gzip_full_02
+
                 assert plain_full_01 + plain_full_02 == plain_full
+                assert gzip_full_02[-1][1] == MockContent.f_size_plain
                 assert plain_full_02[-1][1] == MockContent.f_size_plain
                 assert (
                     newline.join([x[0].decode("UTF-8") for x in plain_full_01]).encode("UTF-8")
                     + newline.encode("UTF-8")
                     + newline.join([x[0].decode("UTF-8") for x in plain_full_02]).encode("UTF-8")
-                    == MockContent.f_content
+                    == MockContent.f_content_plain
+                )
+
+                MockContent.rewind()
+
+                gzip_full_02 = gzip_full_02[: int(len(gzip_full_02) / 2)]
+                plain_full_02 = plain_full_02[: int(len(plain_full_02) / 2)]
+
+                range_start = plain_full_02[-1][1]
+                s3_storage = S3Storage(bucket_name=bucket_name, object_key="dummy.key.gz")
+                gzip_full_03: list[tuple[Union[StorageReader, bytes], int, int]] = list(
+                    s3_storage.get_by_lines(range_start=range_start)
+                )
+
+                s3_storage = S3Storage(bucket_name=bucket_name, object_key="dummy.key")
+                plain_full_03: list[tuple[Union[StorageReader, bytes], int, int]] = list(
+                    s3_storage.get_by_lines(range_start=range_start)
+                )
+
+                diff = set(gzip_full_02) ^ set(plain_full_02)
+                assert not diff
+                assert plain_full_02 == gzip_full_02
+
+                diff = set(gzip_full_03) ^ set(plain_full_03)
+                assert not diff
+                assert plain_full_03 == gzip_full_03
+
+                assert plain_full_01 + plain_full_02 + plain_full_03 == plain_full
+                assert gzip_full_03[-1][1] == MockContent.f_size_plain
+                assert plain_full_03[-1][1] == MockContent.f_size_plain
+                assert (
+                    newline.join([x[0].decode("UTF-8") for x in plain_full_01]).encode("UTF-8")
+                    + newline.encode("UTF-8")
+                    + newline.join([x[0].decode("UTF-8") for x in plain_full_02]).encode("UTF-8")
+                    + newline.encode("UTF-8")
+                    + newline.join([x[0].decode("UTF-8") for x in plain_full_03]).encode("UTF-8")
+                    == MockContent.f_content_plain
                 )
 
                 MockContent.rewind()
@@ -139,10 +188,14 @@ class TestS3Storage(TestCase):
                 range_start = plain_full[-1][1] + random.randint(1, 100)
 
                 s3_storage = S3Storage(bucket_name=bucket_name, object_key="dummy.key.gz")
-                gzip_full_empty: list[tuple[bytes, int, int]] = list(s3_storage.get_by_lines(range_start=range_start))
+                gzip_full_empty: list[tuple[Union[StorageReader, bytes], int, int]] = list(
+                    s3_storage.get_by_lines(range_start=range_start)
+                )
 
                 s3_storage = S3Storage(bucket_name=bucket_name, object_key="dummy.key")
-                plain_full_empty: list[tuple[bytes, int, int]] = list(s3_storage.get_by_lines(range_start=range_start))
+                plain_full_empty: list[tuple[Union[StorageReader, bytes], int, int]] = list(
+                    s3_storage.get_by_lines(range_start=range_start)
+                )
 
                 assert not gzip_full_empty
                 assert not plain_full_empty

--- a/tests/storage/test_s3.py
+++ b/tests/storage/test_s3.py
@@ -14,6 +14,8 @@ from botocore.response import StreamingBody
 
 from storage import S3Storage, StorageReader
 
+_1M: int = 1024 ** 2
+
 
 class MockContent:
     f_size_gzip: int = 0
@@ -32,10 +34,11 @@ class MockContent:
 
     @staticmethod
     def init_content(newline: str) -> None:
+        # every line is from 0 to 20 chars, repeated for 1M: a few megabytes of content
         MockContent.f_content_plain = newline.join(
             [
                 "".join(random.choices(string.ascii_letters + string.digits, k=random.randint(0, 20)))
-                for _ in range(0, 1024 ** 2)
+                for _ in range(0, _1M)
             ]
         ).encode("UTF-8")
 


### PR DESCRIPTION
- Use `gzip.GzipFile` that supports `seek` method on a raw stream: this way we don't need to load the whole gzip content in memory
- CHUNK_SIZE lowered to 1K from 1M, the content is streamed anyway
- `by_lines` decorator still use buffer in memory since the biggest memory amount required will be up to the longest single line in the file plus a few bytes